### PR TITLE
Update LR-FHSS source path in dev_env.cmake

### DIFF
--- a/modules/usp_drivers/dev_env.cmake
+++ b/modules/usp_drivers/dev_env.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 if(SX126X_ENABLE_LR_FHSS)
-  set(LR_FHSS_SRC_PATH "${LBM_SX126X_LIB_DIR}/lr_fhss_driver/src"
+  set(LR_FHSS_SRC_PATH "${LBM_SX126X_LIB_DIR}/"
     CACHE PATH "Path to folder containing LR-FHSS driver" FORCE)
 endif()


### PR DESCRIPTION
Fix the `LR_FHSS_SRC_PATH` to point to the library root directory.

Otherwise 
```
west build --pristine --board nucleo_l476rg/stm32l476xx --shield semtech_sx1261mb2bas samples/usp/lbm/porting_tests/
```

fails with:
```
Make Error at /Users/carlo/work/gardenext_labs/node/semtech/USP/zephyr_workspace/zephyr/cmake/modules/extensions.cmake:533 (target_sources):
  Cannot find source file:

    /Volumes/work/gardenext_labs/node/semtech/USP/zephyr_workspace/modules/lib/usp/smtc_rac_lib/radio_drivers/sx126x_driver/src/lr_fhss_driver/src/lr_fhss_mac.c

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .mpp .m .M .mm .ixx .cppm
  .ccm .cxxm .c++m .h .hh .h++ .hm .hpp .hxx .in .txx .f .F .for .f77 .f90
  .f95 .f03 .hip .ispc
Call Stack (most recent call first):
  /Volumes/work/gardenext_labs/node/semtech/USP/zephyr_workspace/usp_zephyr/modules/usp_drivers/sx126x.cmake:28 (zephyr_library_sources)
  /Volumes/work/gardenext_labs/node/semtech/USP/zephyr_workspace/usp_zephyr/modules/usp/CMakeLists.txt:29 (include)


CMake Error at /Users/carlo/work/gardenext_labs/node/semtech/USP/zephyr_workspace/zephyr/cmake/modules/extensions.cmake:462 (add_library):
  No SOURCES given to target:
  ..__..__..__..__..__..__..__..__..__Volumes__work__gardenext_labs__node__semtech__USP__zephyr_workspace__usp_zephyr__modules__usp
Call Stack (most recent call first):
  /Users/carlo/work/gardenext_labs/node/semtech/USP/zephyr_workspace/zephyr/cmake/modules/extensions.cmake:434 (zephyr_library_named)
  /Volumes/work/gardenext_labs/node/semtech/USP/zephyr_workspace/usp_zephyr/modules/usp/CMakeLists.txt:18 (zephyr_library)
```