### PR TITLE
usp: add STM32WL internal radio HAL driver and NUCLEO-WL55JC board support

### DIFF
--- a/drivers/usp/CMakeLists.txt
+++ b/drivers/usp/CMakeLists.txt
@@ -36,3 +36,15 @@ if(CONFIG_SEMTECH_SX126X)
     sx126x/sx126x_ral_bsp.c
   )
 endif()
+
+# STM32WL internal radio: uses LL functions for reset/busy, NVIC for DIO1
+if(CONFIG_SEMTECH_SX126X_STM32WL)
+  zephyr_library_sources(
+    sx126x/sx126x_hal_stm32wl.c
+    sx126x/sx126x_board_stm32wl.c
+  )
+
+  zephyr_library_sources_ifdef(CONFIG_LORA_BASICS_MODEM_DRIVERS_RAL_RALF
+    sx126x/sx126x_ral_bsp_stm32wl.c
+  )
+endif()

--- a/drivers/usp/Kconfig.sx12xx
+++ b/drivers/usp/Kconfig.sx12xx
@@ -4,10 +4,22 @@
 # LoRa transceiver drivers configuration options
 
 config SEMTECH_SX126X
-	bool "Semtech SX126x family LoRa transceiver driver"
+	bool "Semtech SX126x family LoRa transceiver driver (external SPI)"
 	default y
-	depends on DT_HAS_SEMTECH_SX1261_NEW_ENABLED || DT_HAS_SEMTECH_SX1262_NEW_ENABLED || DT_HAS_SEMTECH_SX1268_NEW_ENABLED || DT_HAS_ST_STM32WL_SUBGHZ_RADIO_ENABLED
+	depends on DT_HAS_SEMTECH_SX1261_NEW_ENABLED || DT_HAS_SEMTECH_SX1262_NEW_ENABLED || DT_HAS_SEMTECH_SX1268_NEW_ENABLED
 	select SPI
 	select GPIO
 	help
-	  Enable driver for the SX126x family and stm32wl embedded LoRa transceiver driver
+	  Enable driver for the external SX126x family (SX1261/SX1262/SX1268)
+	  connected via SPI with explicit reset, busy, and DIO GPIO pins.
+
+config SEMTECH_SX126X_STM32WL
+	bool "Semtech SX126x driver for STM32WL internal radio"
+	default y
+	depends on DT_HAS_SEMTECH_SX126X_STM32WL_ENABLED
+	select SPI
+	help
+	  Enable driver for the SX126x-compatible radio embedded inside the
+	  STM32WLE5 / STM32WL55 SoC. Reset and busy signals are accessed via
+	  internal LL register functions (no external GPIO pins required).
+	  DIO1 interrupts are delivered through NVIC IRQ 50 (SUBGHZ_Radio_IRQn).

--- a/drivers/usp/sx126x/STM32WL_vs_SX1262.md
+++ b/drivers/usp/sx126x/STM32WL_vs_SX1262.md
@@ -1,0 +1,190 @@
+# STM32WLE5 Internal Radio vs External SX1262 — Porting Notes
+
+This document explains the architectural differences between the STM32WLE5 embedded
+sub-GHz radio and a classic external SX1262, and why the STM32WL-specific driver
+(`sx126x_hal_stm32wl.c`, `sx126x_board_stm32wl.c`) differs from the standard one
+(`sx126x_hal.c`, `sx126x_board.c`).
+
+---
+
+## 1. SPI Bus: Internal Peripheral vs External GPIO
+
+| Signal | External SX1262 | STM32WLE5 |
+|--------|-----------------|-----------|
+| SPI bus | Any SPI peripheral | `subghzspi` — dedicated internal peripheral |
+| NSS (chip select) | GPIO pin, driven manually | Internal (managed by `subghzspi` hardware) |
+| BUSY signal | `BUSY` GPIO pin (HIGH = radio busy) | `PWR_SR2.RFBUSYS` register bit |
+
+### RFBUSYS busy-wait ordering
+
+On an external SX1262, the host reads the `BUSY` pin **before** asserting NSS to ensure
+the radio is ready. On STM32WL, `RFBUSYS` reflects whether NSS is currently asserted —
+polling it **before** starting a transaction causes a deadlock:
+
+> We wait for NSS to deassert, but NSS only deasserts when the transaction we have not
+> yet started completes.
+
+The correct sequence on STM32WL:
+1. Start the SPI transaction (`spi_write_dt` / `spi_transceive_dt`).
+2. Wait for `RFBUSYS = 0` (NSS deasserted, wakeup complete).
+
+Special case: after `SetSleep`, `RFBUSYS` stays HIGH during sleep. Do not poll it;
+wait the mandatory 500 µs calibration time instead.
+
+---
+
+## 2. Reset: External GPIO vs Internal RCC
+
+| | External SX1262 | STM32WLE5 |
+|--|-----------------|-----------|
+| Reset mechanism | `NRESET` GPIO pin, active low | `LL_RCC_RF_EnableReset()` / `LL_RCC_RF_DisableReset()` |
+
+`sx126x_hal_reset()` uses STM32 LL RCC calls instead of toggling a GPIO:
+
+```c
+LL_RCC_RF_EnableReset();
+k_msleep(20);
+LL_RCC_RF_DisableReset();
+k_msleep(10);
+```
+
+---
+
+## 3. DIO1 Radio Interrupt: GPIO EXTI vs NVIC IRQ 50 (level-triggered)
+
+This is the most impactful difference and required two separate fixes.
+
+| | External SX1262 | STM32WLE5 |
+|--|-----------------|-----------|
+| DIO1 signal | GPIO pin → EXTI, edge-triggered | EXTI line 44 → **NVIC IRQ 50** (`SUBGHZ_Radio_IRQn`) |
+| Trigger type | Rising edge (one pulse per event) | **Level-triggered** — stays HIGH until `ClearIrqStatus` sent |
+
+### Problem: IRQ storm
+
+With a level-triggered source, if the ISR returns while DIO1 is still HIGH (i.e., before
+`ClearIrqStatus` is sent over SPI by the USP thread), the NVIC immediately re-enters the
+ISR. This creates an infinite loop that starves every thread.
+
+**Fix — disable in ISR:**
+
+```c
+static void sx126x_stm32wl_radio_isr(const struct device *dev)
+{
+    irq_disable(DT_IRQ_BY_IDX(..., 0, irq));   /* prevent re-entry storm */
+    sx126x_stm32wl_event_callback(data);        /* wake the USP thread */
+}
+```
+
+### Problem: IRQ never re-enabled after first event
+
+`irq_enable(50)` is called once at init via `smtc_modem_hal_irq_config_radio_irq()`.
+The Radio Planner (RP) does **not** call `smtc_modem_hal_enable_modem_irq()` after
+processing radio events — that function is only used by `fifo_ctrl.c` for its own
+critical sections.
+
+Result: after TX_DONE fires and the ISR disables IRQ 50, the interrupt stays disabled.
+`SetRx` is sent later but the `RX_TIMEOUT` / `RX_DONE` event never reaches the CPU.
+The RP watchdog (`RP_FAILSAFE`) fires after 128 s.
+
+**Fix — re-enable in `sx126x_hal_write()`:**
+
+```c
+/* At the end of sx126x_hal_write(), after every successful SPI write: */
+lora_transceiver_board_enable_interrupt(dev);   /* = irq_enable(50) */
+```
+
+After each SPI write completes and `wait_on_busy()` confirms the radio is ready,
+DIO1 is either already LOW or will deassert on the imminent `ClearIrqStatus` write.
+Re-arming NVIC IRQ 50 at this point is always safe and ensures no event is missed.
+
+### ISR chain (NO_THREAD mode)
+
+```
+NVIC IRQ 50
+  └─ sx126x_stm32wl_radio_isr()      irq_disable(50)
+       └─ prv_transceiver_event_cb()
+            └─ rp_radio_irq_callback()   radio_irq_flag = true
+                 └─ smtc_modem_hal_wake_up()   k_sem_give()
+                      └─ (main loop wakes, calls smtc_modem_run_engine / smtc_rac_run_engine)
+                           └─ rp_callback() → rp_irq_get_status() → ClearIrqStatus (SPI)
+                                └─ sx126x_hal_write() → lora_transceiver_board_enable_interrupt()
+                                                         irq_enable(50)  ← re-armed here
+```
+
+---
+
+## 4. RF Switch: DIO2 vs External MCU GPIOs
+
+`dio2-as-rf-switch` is an SX1262 hardware feature: setting it tells the chip to
+autonomously toggle DIO2 during TX. On STM32WL boards, DIO2 is not wired to the RF
+switch; the MCU must drive GPIOs manually before each `SetRx` / `SetTx` SPI command.
+
+| | Typical SX1262 board | RAK3172_SIP / RAK3172LP_SIP | NUCLEO-WL55JC |
+|--|----------------------|-----------------------------|----------------|
+| RF switch control | `dio2-as-rf-switch` (chip-driven) | PA1 = RF_TX (ACTIVE_HIGH), PA0 = RF_RX (ACTIVE_HIGH) | PC4 = FE_CTRL1 TX (ACTIVE_LOW), PC5 = FE_CTRL2 RX (ACTIVE_LOW) |
+
+> **Note:** plain RAK3172 uses an external SX1262 over SPI (standard sx126x driver).
+> It does NOT use this STM32WL driver and has its own GPIO wiring.
+
+`sx126x_stm32wl_set_rf_switch()` in `sx126x_hal_stm32wl.c` is called at the start of
+every `sx126x_hal_write()`, keyed on the command opcode:
+
+| Opcode | tx_rf_switch | rx_rf_switch |
+|--------|--------------|--------------|
+| `0x83` SetTx | asserted | deasserted |
+| `0x82` SetRx | deasserted | asserted |
+| anything else | deasserted | deasserted |
+
+Active level (HIGH or LOW) is taken from the DTS `tx-enable-gpios` / `rx-enable-gpios`
+`GPIO_ACTIVE_HIGH` / `GPIO_ACTIVE_LOW` flags — no hard-coded polarity in the driver.
+
+---
+
+## 5. TCXO: Same Mechanism
+
+Both use `SetDio3AsTcxoCtrl` to let the SX126x supply the regulated voltage to the
+external TCXO via DIO3. No implementation difference.
+- RAK3172_SIP / RAK3172LP_SIP : 1.7 V, 5 ms startup delay
+- NUCLEO-WL55JC               : 1.7 V, 5 ms startup delay
+
+---
+
+## 6. PA: LP vs HP depending on board variant
+
+| | External SX1262 | RAK3172_SIP / NUCLEO-WL55JC | RAK3172LP_SIP |
+|--|-----------------|----------------------------|---------------|
+| PA type | HP, up to +22 dBm | HP (`rfo-hp`), up to +22 dBm | LP (`rfo-lp`), up to +14 dBm |
+| Compile define | `SX1262` | `SX1261` (USP library) | `SX1261` (USP library) |
+
+The `power-amplifier-output` DTS property maps to `pa_is_lp` in the driver config struct:
+- `"rfo-hp"` → `pa_is_lp = false` → HP PA path, calibration for +22 dBm
+- `"rfo-lp"` → `pa_is_lp = true`  → LP PA path, calibration tables matching SX1261
+
+In both cases `SX1261` must be passed to the USP library CMake (`-DSX1261=1`) because
+the STM32WL PA config registers match the SX1261 LP PA, even on the HP variant.
+
+---
+
+## Summary
+
+The external SX1262 exposes every control signal as a GPIO pin with well-defined
+edge-triggered behaviour. The STM32WLE5 embeds the same radio core but replaces every
+external signal with an internal MCU register or peripheral:
+
+| External SX1262 signal | STM32WLE5 equivalent | Driver change |
+|------------------------|----------------------|---------------|
+| `BUSY` GPIO | `PWR_SR2.RFBUSYS` | Poll after SPI, not before |
+| `NRESET` GPIO | RCC SubGHz reset | Use LL RCC API |
+| DIO1 GPIO (edge) | NVIC IRQ 50 (level) | `irq_disable` in ISR + `irq_enable` after each SPI write |
+| SPI + NSS GPIO | Internal `subghzspi` | Use Zephyr `subghzspi` device node |
+| DIO2 RF switch | Not wired → MCU GPIOs | Drive tx/rx GPIOs before SetRx/SetTx (polarity from DTS) |
+| SX1262 HP PA | HP or LP depending on board | `SX1261` define; `rfo-hp` (RAK3172_SIP, NUCLEO) or `rfo-lp` (RAK3172LP_SIP) |
+
+### Board summary
+
+| Board | PA | RF switch | Regulator | Driver |
+|-------|----|-----------|-----------|--------|
+| RAK3172 (non-SiP) | HP +22 dBm | External SX1262 DIO2 | — | **standard sx126x (SPI)** |
+| RAK3172_SIP | HP +22 dBm | PA1/PA0 ACTIVE_HIGH | LDO | **this driver** |
+| RAK3172LP_SIP | LP +14 dBm | PA1/PA0 ACTIVE_HIGH | LDO | **this driver** |
+| NUCLEO-WL55JC | HP +22 dBm | PC4/PC5 ACTIVE_LOW | DC-DC | **this driver** |

--- a/drivers/usp/sx126x/sx126x_board_stm32wl.c
+++ b/drivers/usp/sx126x/sx126x_board_stm32wl.c
@@ -1,0 +1,290 @@
+/**
+ * @file      sx126x_board_stm32wl.c
+ *
+ * @brief     Zephyr device registration and interrupt wiring for the
+ *            STM32WL internal SX126x radio.
+ *
+ * On STM32WL the radio DIO1 interrupt is delivered via NVIC IRQ 50
+ * (SUBGHZ_Radio_IRQn). There are no external GPIO pins to configure.
+ *
+ * This file replaces sx126x_board.c when CONFIG_SEMTECH_SX126X_STM32WL is set.
+ *
+ * Copyright (c) 2026 Semtech Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ * Created by Charles-Henri Hallard (charles@evolyenergy.com)
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/irq.h>
+#include <zephyr/version.h>
+
+/* STM32WL EXTI / LL helpers for enabling the SubGHz radio interrupt line */
+#include <stm32wlxx_ll_exti.h>
+
+#include <zephyr/usp/lora_lbm_transceiver.h>
+#include "sx126x_stm32wl_hal_context.h"
+
+LOG_MODULE_REGISTER( lora_sx126x, CONFIG_LORA_BASICS_MODEM_DRIVERS_LOG_LEVEL );
+
+/* Required by DEVICE_DT_INST_GET() inside IRQ_CONNECT() */
+#define DT_DRV_COMPAT semtech_sx126x_stm32wl
+
+#define SX126X_STM32WL_SPI_OPERATION \
+    ( SPI_WORD_SET( 8 ) | SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB )
+
+/* ---------------------------------------------------------------------------
+ * Event / interrupt handling
+ * ---------------------------------------------------------------------------
+ */
+
+static void sx126x_stm32wl_event_callback( struct sx126x_stm32wl_hal_context_data_t* data )
+{
+#if defined( CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_OWN_THREAD )
+    k_sem_give( &data->gpio_sem );
+#elif defined( CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_GLOBAL_THREAD )
+    k_work_submit( &data->work );
+#elif defined( CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_NO_THREAD )
+    if( data->event_interrupt_cb )
+    {
+        data->event_interrupt_cb( data->sx126x_dev );
+    }
+#endif
+}
+
+#ifdef CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_OWN_THREAD
+static void sx126x_stm32wl_thread( struct sx126x_stm32wl_hal_context_data_t* data )
+{
+    while( 1 )
+    {
+        k_sem_take( &data->gpio_sem, K_FOREVER );
+        if( data->event_interrupt_cb )
+        {
+            data->event_interrupt_cb( data->sx126x_dev );
+        }
+    }
+}
+#endif /* CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_OWN_THREAD */
+
+#ifdef CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_GLOBAL_THREAD
+static void sx126x_stm32wl_work_cb( struct k_work* work )
+{
+    struct sx126x_stm32wl_hal_context_data_t* data =
+        CONTAINER_OF( work, struct sx126x_stm32wl_hal_context_data_t, work );
+
+    if( data->event_interrupt_cb )
+    {
+        data->event_interrupt_cb( data->sx126x_dev );
+    }
+}
+#endif /* CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_GLOBAL_THREAD */
+
+/* ISR for the STM32WL SUBGHZ_Radio IRQ (NVIC IRQ 50) */
+static void sx126x_stm32wl_radio_isr( const struct device* dev )
+{
+#ifdef CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER
+    struct sx126x_stm32wl_hal_context_data_t* data = dev->data;
+
+    /* EXTI line 44 (SubGHz radio DIO1) is level-triggered: it stays
+     * asserted until the host sends ClearIrqStatus to the radio over SPI,
+     * which happens in the USP thread (smtc_modem_run_engine).  If we
+     * return from this ISR with DIO1 still HIGH the NVIC immediately
+     * re-enters it, creating an IRQ storm that starves the USP thread.
+     *
+     * Fix: disable IRQ 50 here.  smtc_modem_hal_enable_modem_irq() →
+     * lora_transceiver_board_enable_interrupt() will re-enable it after
+     * the LBM has cleared the radio IRQ register and DIO1 goes LOW. */
+    irq_disable( DT_IRQ_BY_IDX( DT_INST( 0, semtech_sx126x_stm32wl ), 0, irq ) );
+
+    sx126x_stm32wl_event_callback( data );
+#endif
+}
+
+/* ---------------------------------------------------------------------------
+ * Board API (called by the USP RAC layer)
+ * ---------------------------------------------------------------------------
+ */
+
+void lora_transceiver_board_attach_interrupt( const struct device* dev, event_cb_t cb )
+{
+#ifdef CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER
+    struct sx126x_stm32wl_hal_context_data_t* data = dev->data;
+
+    data->event_interrupt_cb = cb;
+#else
+    LOG_ERR( "Event trigger not supported!" );
+#endif
+}
+
+void lora_transceiver_board_enable_interrupt( const struct device* dev )
+{
+    irq_enable( DT_IRQ_BY_IDX( DT_INST( 0, semtech_sx126x_stm32wl ), 0, irq ) );
+}
+
+void lora_transceiver_board_disable_interrupt( const struct device* dev )
+{
+    irq_disable( DT_IRQ_BY_IDX( DT_INST( 0, semtech_sx126x_stm32wl ), 0, irq ) );
+}
+
+uint32_t lora_transceiver_get_tcxo_startup_delay_ms( const struct device* dev )
+{
+    const struct sx126x_stm32wl_hal_context_cfg_t* config = dev->config;
+
+    return config->tcxo_cfg.wakeup_time_ms;
+}
+
+/* ---------------------------------------------------------------------------
+ * Driver init
+ * ---------------------------------------------------------------------------
+ */
+
+static int sx126x_stm32wl_init( const struct device* dev )
+{
+    const struct sx126x_stm32wl_hal_context_cfg_t* config = dev->config;
+    struct sx126x_stm32wl_hal_context_data_t*      data   = dev->data;
+    int                                            ret    = 0;
+
+    if( !device_is_ready( config->spi.bus ) )
+    {
+        LOG_ERR( "subghzspi bus not ready" );
+        return -EINVAL;
+    }
+
+    /* Configure external RF switch GPIOs (both idle/low at startup) */
+    if( config->tx_rf_switch.port != NULL )
+    {
+        if( !gpio_is_ready_dt( &config->tx_rf_switch ) )
+        {
+            LOG_ERR( "TX RF switch GPIO not ready" );
+            return -ENODEV;
+        }
+        gpio_pin_configure_dt( &config->tx_rf_switch, GPIO_OUTPUT_INACTIVE );
+    }
+    if( config->rx_rf_switch.port != NULL )
+    {
+        if( !gpio_is_ready_dt( &config->rx_rf_switch ) )
+        {
+            LOG_ERR( "RX RF switch GPIO not ready" );
+            return -ENODEV;
+        }
+        gpio_pin_configure_dt( &config->rx_rf_switch, GPIO_OUTPUT_INACTIVE );
+    }
+
+    data->radio_status               = RADIO_AWAKE;
+    data->tx_power_offset_db_current = config->tx_power_offset_db;
+
+#ifdef CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER
+    data->sx126x_dev = dev;
+
+#ifdef CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_GLOBAL_THREAD
+    data->work.handler = sx126x_stm32wl_work_cb;
+#endif
+#ifdef CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_OWN_THREAD
+    k_sem_init( &data->gpio_sem, 0, K_SEM_MAX_LIMIT );
+    k_thread_create( &data->thread, data->thread_stack,
+                     CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_THREAD_STACK_SIZE,
+                     ( k_thread_entry_t ) sx126x_stm32wl_thread, data, NULL, NULL,
+                     K_PRIO_COOP( CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_THREAD_PRIORITY ),
+                     0, K_NO_WAIT );
+#endif
+
+    /* Connect the SUBGHZ_Radio IRQ (line 44 in the EXTI block, NVIC IRQ 50).
+     * LL_EXTI_LINE_44 enables the wakeup-from-sleep path for the radio. */
+    IRQ_CONNECT( DT_IRQ_BY_IDX( DT_INST( 0, semtech_sx126x_stm32wl ), 0, irq ),
+                 DT_IRQ_BY_IDX( DT_INST( 0, semtech_sx126x_stm32wl ), 0, priority ),
+                 sx126x_stm32wl_radio_isr,
+                 DEVICE_DT_INST_GET( 0 ), 0 );
+
+    LL_EXTI_EnableIT_32_63( LL_EXTI_LINE_44 );
+    irq_enable( DT_IRQ_BY_IDX( DT_INST( 0, semtech_sx126x_stm32wl ), 0, irq ) );
+
+#endif /* CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER */
+
+    return ret;
+}
+
+/* ---------------------------------------------------------------------------
+ * PM action (placeholder — power management is handled by LBM itself)
+ * ---------------------------------------------------------------------------
+ */
+
+#if IS_ENABLED( CONFIG_PM_DEVICE )
+static int sx126x_stm32wl_pm_action( const struct device* dev, enum pm_device_action action )
+{
+    switch( action )
+    {
+    case PM_DEVICE_ACTION_RESUME:
+    case PM_DEVICE_ACTION_SUSPEND:
+        break;
+    default:
+        return -ENOTSUP;
+    }
+    return 0;
+}
+#endif
+
+/* ---------------------------------------------------------------------------
+ * Device tree instantiation macros
+ * ---------------------------------------------------------------------------
+ */
+
+#if ZEPHYR_VERSION_CODE < ZEPHYR_VERSION( 4, 3, 0 )
+    #define SX126X_STM32WL_SPI_SPEC( node_id ) \
+        SPI_DT_SPEC_GET( node_id, SX126X_STM32WL_SPI_OPERATION, 0 )
+#else
+    #define SX126X_STM32WL_SPI_SPEC( node_id ) \
+        SPI_DT_SPEC_GET( node_id, SX126X_STM32WL_SPI_OPERATION )
+#endif
+
+/* Derive xosc_cfg: if tcxo-power-startup-delay-ms is absent or 0 → crystal,
+ * else TCXO controlled via DIO3. */
+#define SX126X_STM32WL_XOSC_CFG( node_id ) \
+    ( DT_PROP_OR( node_id, tcxo_power_startup_delay_ms, 0 ) == 0 \
+        ? RAL_XOSC_CFG_XTAL \
+        : RAL_XOSC_CFG_TCXO_RADIO_CTRL )
+
+#define SX126X_STM32WL_CFG_TCXO( node_id )                                          \
+    .tcxo_cfg = {                                                                    \
+        .xosc_cfg       = SX126X_STM32WL_XOSC_CFG( node_id ),                       \
+        .voltage        = DT_PROP_OR( node_id, dio3_tcxo_voltage, 0 ),               \
+        .wakeup_time_ms = DT_PROP_OR( node_id, tcxo_power_startup_delay_ms, 0 ),     \
+    }
+
+#define SX126X_STM32WL_CONFIG( node_id )                                              \
+    {                                                                                 \
+        .spi                  = SX126X_STM32WL_SPI_SPEC( node_id ),                   \
+        .tx_rf_switch         = GPIO_DT_SPEC_GET_OR( node_id, tx_enable_gpios, {0} ), \
+        .rx_rf_switch         = GPIO_DT_SPEC_GET_OR( node_id, rx_enable_gpios, {0} ), \
+        .dio2_tx_enable       = DT_PROP( node_id, dio2_tx_enable ),                   \
+        SX126X_STM32WL_CFG_TCXO( node_id ),                                           \
+        .capa_xta             = DT_PROP_OR( node_id, xtal_capacitor_value_xta, 0xFF ),\
+        .capa_xtb             = DT_PROP_OR( node_id, xtal_capacitor_value_xtb, 0xFF ),\
+        /* regulator-ldo is a boolean: present = LDO, absent = DC-DC */               \
+        .reg_mode             = DT_PROP( node_id, regulator_ldo )                     \
+                                    ? SX126X_REG_MODE_LDO : SX126X_REG_MODE_DCDC,    \
+        .tx_power_offset_db   = DT_PROP_OR( node_id, tx_power_offset, 0 ),            \
+        .rx_boosted           = DT_PROP_OR( node_id, rx_boosted, false ),             \
+        .pa_ramp_time         = DT_PROP_OR( node_id, pa_ramp_time, 0x02 ),            \
+        /* DT_ENUM_IDX returns 0 for "rfo-lp" (first enum) and 1 for "rfo-hp" */  \
+        .pa_is_lp             = ( DT_ENUM_IDX( node_id, power_amplifier_output ) == 0 ), \
+        .pa_lp_max_power_dbm  = DT_PROP_OR( node_id, rfo_lp_max_power, 14 ),          \
+        .pa_hp_max_power_dbm  = DT_PROP_OR( node_id, rfo_hp_max_power, 22 ),          \
+    }
+
+#define SX126X_STM32WL_DEVICE_INIT( node_id )                                             \
+    DEVICE_DT_DEFINE( node_id, sx126x_stm32wl_init, PM_DEVICE_DT_GET( node_id ),          \
+                      &sx126x_stm32wl_data_##node_id, &sx126x_stm32wl_config_##node_id,   \
+                      POST_KERNEL, CONFIG_LORA_BASICS_MODEM_DRIVERS_INIT_PRIORITY, NULL );
+
+#define SX126X_STM32WL_DEFINE( node_id )                                                          \
+    static struct sx126x_stm32wl_hal_context_data_t      sx126x_stm32wl_data_##node_id;           \
+    static const struct sx126x_stm32wl_hal_context_cfg_t sx126x_stm32wl_config_##node_id =        \
+        SX126X_STM32WL_CONFIG( node_id );                                                         \
+    PM_DEVICE_DT_DEFINE( node_id, sx126x_stm32wl_pm_action );                                     \
+    SX126X_STM32WL_DEVICE_INIT( node_id )
+
+/* Instantiate one device for every enabled semtech,sx126x-stm32wl node */
+DT_FOREACH_STATUS_OKAY( semtech_sx126x_stm32wl, SX126X_STM32WL_DEFINE )

--- a/drivers/usp/sx126x/sx126x_hal_stm32wl.c
+++ b/drivers/usp/sx126x/sx126x_hal_stm32wl.c
@@ -1,0 +1,250 @@
+/**
+ * @file      sx126x_hal_stm32wl.c
+ *
+ * @brief     SX126x HAL implementation for the STM32WL internal radio.
+ *
+ * On STM32WLE5/STM32WL55, the SX126x-compatible radio is embedded inside
+ * the SoC. Reset and busy signals are not exposed as external GPIO pins but
+ * are accessed through CPU-internal registers (RCC and PWR). The SPI bus is
+ * the internal subghzspi peripheral.
+ *
+ * This file replaces sx126x_hal.c when CONFIG_SEMTECH_SX126X_STM32WL is set.
+ *
+ * Busy-wait strategy
+ * ------------------
+ * On an external SX126x the BUSY pin is high while the radio processes a
+ * command and low when it is ready for the next one.  On STM32WL the
+ * equivalent is PWR_SR2.RFBUSYS:
+ *
+ *   RFBUSYS = 1  NSS is asserted (SPI transaction in progress) OR the radio
+ *                is completing its wakeup from deep-sleep.
+ *   RFBUSYS = 0  NSS is deasserted and the radio has finished any wakeup.
+ *
+ * IMPORTANT: RFBUSYS can be 1 at power-on or after a peripheral reset because
+ * a previous SPI transaction may have left NSS asserted.  Polling RFBUSYS
+ * BEFORE starting a transaction therefore creates a deadlock – we wait for NSS
+ * to deassert, but NSS only deasserts when the transaction we have not yet
+ * started completes.  The correct sequence is:
+ *
+ *   1. Start the SPI transaction via spi_write_dt() / spi_transceive_dt().
+ *   2. Wait for RFBUSYS = 0 (NSS deasserted, wakeup complete).
+ *
+ * Copyright (c) 2026 Semtech Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ * Created by Charles-Henri Hallard (charles@evolyenergy.com)
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/types.h>
+#include <zephyr/irq.h>
+
+/* STM32WL low-level register helpers */
+#include <stm32wlxx_ll_pwr.h>
+#include <stm32wlxx_ll_rcc.h>
+
+#include <sx126x_hal.h>
+#include "sx126x_stm32wl_hal_context.h"
+#include <zephyr/usp/lora_lbm_transceiver.h>
+
+LOG_MODULE_DECLARE( lora_sx126x, CONFIG_LORA_BASICS_MODEM_DRIVERS_LOG_LEVEL );
+
+/* SX126x command opcodes used for RF switch and sleep handling */
+#define SX126X_SET_STANDBY_OPCODE 0x80U /* radio → STDBY_RC or STDBY_XOSC   */
+#define SX126X_SET_RX_OPCODE      0x82U /* radio → RX mode                   */
+#define SX126X_SET_TX_OPCODE      0x83U /* radio → TX mode                   */
+#define SX126X_SET_SLEEP_OPCODE   0x84U /* radio → sleep mode                */
+
+/* NOP / GetStatus opcode – any byte triggers wakeup from sleep */
+#define SX126X_NOP_OPCODE 0x00U
+
+/**
+ * @brief Drive external RF switch GPIOs according to the radio command.
+ *
+ * Call this BEFORE sending the SPI command so the RF path is connected
+ * by the time the radio starts transmitting or receiving.
+ *
+ * Only SetTx (0x83) and SetRx (0x82) change the switch position.
+ * All other commands (SetStandby, SetSleep, configuration writes, …)
+ * put both pins low (idle / safe state).
+ */
+static void sx126x_stm32wl_set_rf_switch( const struct sx126x_stm32wl_hal_context_cfg_t* config,
+                                          uint8_t opcode )
+{
+    bool tx_on = ( opcode == SX126X_SET_TX_OPCODE );
+    bool rx_on = ( opcode == SX126X_SET_RX_OPCODE );
+
+    if( config->tx_rf_switch.port != NULL )
+    {
+        gpio_pin_set_dt( &config->tx_rf_switch, tx_on ? 1 : 0 );
+    }
+    if( config->rx_rf_switch.port != NULL )
+    {
+        gpio_pin_set_dt( &config->rx_rf_switch, rx_on ? 1 : 0 );
+    }
+}
+
+/**
+ * @brief Wait until RFBUSYS is cleared (NSS deasserted, radio ready).
+ *
+ * Must be called AFTER an SPI transaction, never before.  Calling it before
+ * a transaction while RFBUSYS is already 1 (stale NSS from a previous cycle)
+ * would block forever.
+ */
+static void sx126x_stm32wl_wait_on_busy( void )
+{
+    uint32_t end = k_uptime_get_32( ) + CONFIG_LORA_BASICS_MODEM_DRIVERS_HAL_WAIT_ON_BUSY_TIMEOUT_MSEC;
+
+    while( k_uptime_get_32( ) <= end )
+    {
+        /* RFBUSYS = 0 means NSS is deasserted and wakeup (if any) is done */
+        if( !LL_PWR_IsActiveFlag_RFBUSYS( ) )
+        {
+            return;
+        }
+        k_usleep( 100 );
+    }
+
+    LOG_ERR( "Timeout of %dms waiting for STM32WL RFBUSYS to clear",
+             CONFIG_LORA_BASICS_MODEM_DRIVERS_HAL_WAIT_ON_BUSY_TIMEOUT_MSEC );
+    k_oops( );
+}
+
+/* ---------------------------------------------------------------------------
+ * Public HAL API
+ * ---------------------------------------------------------------------------
+ */
+
+sx126x_hal_status_t sx126x_hal_write( const void* context, const uint8_t* command, const uint16_t command_length,
+                                      const uint8_t* data, const uint16_t data_length )
+{
+    const struct device*                           dev      = ( const struct device* ) context;
+    const struct sx126x_stm32wl_hal_context_cfg_t* config   = dev->config;
+    struct sx126x_stm32wl_hal_context_data_t*      dev_data = dev->data;
+    int                                            ret;
+
+    const struct spi_buf tx_bufs[] = {
+        { .buf = ( void* ) command, .len = command_length },
+        { .buf = ( void* ) data,    .len = data_length    },
+    };
+    const struct spi_buf_set tx_buf_set = { tx_bufs, .count = ARRAY_SIZE( tx_bufs ) };
+
+    /* Drive external RF switch before the SPI command reaches the radio.
+     * SetTx → TX path; SetRx → RX path; anything else → idle (both low). */
+    sx126x_stm32wl_set_rf_switch( config, command[0] );
+
+    /* No pre-SPI busy check: RFBUSYS may be 1 at startup due to a stale NSS
+     * from a previous power cycle.  The wait belongs after the transaction. */
+
+    ret = spi_write_dt( &config->spi, &tx_buf_set );
+    if( ret )
+    {
+        return SX126X_HAL_STATUS_ERROR;
+    }
+
+    if( command[0] == SX126X_SET_SLEEP_OPCODE )
+    {
+        /* After SET_SLEEP the radio enters sleep mode.  RFBUSYS will stay high
+         * during sleep, so we must not poll it.  Instead wait the mandatory
+         * 500 µs calibration time and record the new state. */
+        dev_data->radio_status = RADIO_SLEEP;
+        k_usleep( 500 );
+    }
+    else
+    {
+        /* Wait for NSS to deassert and any wakeup sequence to complete.
+         * If the radio was asleep, RFBUSYS stays 1 until wakeup is done. */
+        sx126x_stm32wl_wait_on_busy( );
+        dev_data->radio_status = RADIO_AWAKE;
+    }
+
+    /* Re-enable the SUBGHZ radio interrupt after every SPI write.
+     *
+     * The ISR (sx126x_stm32wl_radio_isr) calls irq_disable() to prevent an
+     * IRQ storm caused by EXTI line 44 being level-triggered: DIO1 stays HIGH
+     * until ClearIrqStatus is sent over SPI.  Once the SPI transaction
+     * completes here (DIO1 is either already LOW or will deassert on the very
+     * next ClearIrqStatus write), it is safe to re-arm the NVIC line so the
+     * next radio event (RX_DONE, RX_TIMEOUT, TX_DONE, …) is not missed. */
+    lora_transceiver_board_enable_interrupt( dev );
+
+    return SX126X_HAL_STATUS_OK;
+}
+
+sx126x_hal_status_t sx126x_hal_read( const void* context, const uint8_t* command, const uint16_t command_length,
+                                     uint8_t* data, const uint16_t data_length )
+{
+    const struct device*                           dev    = ( const struct device* ) context;
+    const struct sx126x_stm32wl_hal_context_cfg_t* config = dev->config;
+    struct sx126x_stm32wl_hal_context_data_t*      dev_data = dev->data;
+    int                                            ret;
+
+    const struct spi_buf tx_bufs[] = {
+        { .buf = ( uint8_t* ) command, .len = command_length },
+        { .buf = NULL,                 .len = data_length    },
+    };
+    const struct spi_buf rx_bufs[] = {
+        { .buf = NULL, .len = command_length },
+        { .buf = data, .len = data_length    },
+    };
+    const struct spi_buf_set tx_buf_set = { .buffers = tx_bufs, .count = ARRAY_SIZE( tx_bufs ) };
+    const struct spi_buf_set rx_buf_set = { .buffers = rx_bufs, .count = ARRAY_SIZE( rx_bufs ) };
+
+    /* No pre-SPI busy check for the same reason as sx126x_hal_write(). */
+
+    ret = spi_transceive_dt( &config->spi, &tx_buf_set, &rx_buf_set );
+    if( ret )
+    {
+        return SX126X_HAL_STATUS_ERROR;
+    }
+
+    /* Wait for NSS to deassert after the read transaction. */
+    sx126x_stm32wl_wait_on_busy( );
+    dev_data->radio_status = RADIO_AWAKE;
+
+    return SX126X_HAL_STATUS_OK;
+}
+
+sx126x_hal_status_t sx126x_hal_reset( const void* context )
+{
+    const struct device*                           dev    = ( const struct device* ) context;
+    const struct sx126x_stm32wl_hal_context_cfg_t* config = dev->config;
+    struct sx126x_stm32wl_hal_context_data_t*      data   = dev->data;
+
+    /* On STM32WL the radio reset is an internal RCC SubGHz sub-system reset.
+     * There is no external NRESET pin. */
+    LL_RCC_RF_EnableReset( );
+    k_msleep( 20 );
+    LL_RCC_RF_DisableReset( );
+    k_msleep( 10 );
+
+    /* After reset the radio is in standby — put RF switch in idle state. */
+    sx126x_stm32wl_set_rf_switch( config, SX126X_SET_STANDBY_OPCODE );
+    data->radio_status = RADIO_AWAKE;
+    return SX126X_HAL_STATUS_OK;
+}
+
+sx126x_hal_status_t sx126x_hal_wakeup( const void* context )
+{
+    const struct device*                           dev      = ( const struct device* ) context;
+    const struct sx126x_stm32wl_hal_context_cfg_t* config   = dev->config;
+    struct sx126x_stm32wl_hal_context_data_t*      dev_data = dev->data;
+
+    if( dev_data->radio_status == RADIO_SLEEP )
+    {
+        /* Any SPI transaction (NSS assertion) wakes the radio from sleep.
+         * Send a NOP byte to trigger the wakeup, then wait for RFBUSYS = 0
+         * which confirms the wakeup sequence has completed. */
+        uint8_t                  nop        = SX126X_NOP_OPCODE;
+        const struct spi_buf     tx_buf     = { .buf = &nop, .len = 1 };
+        const struct spi_buf_set tx_buf_set = { .buffers = &tx_buf, .count = 1 };
+
+        spi_write_dt( &config->spi, &tx_buf_set );
+        sx126x_stm32wl_wait_on_busy( );
+        dev_data->radio_status = RADIO_AWAKE;
+    }
+
+    return SX126X_HAL_STATUS_OK;
+}

--- a/drivers/usp/sx126x/sx126x_ral_bsp_stm32wl.c
+++ b/drivers/usp/sx126x/sx126x_ral_bsp_stm32wl.c
@@ -1,0 +1,268 @@
+/**
+ * @file      sx126x_ral_bsp_stm32wl.c
+ *
+ * @brief     RAL BSP implementation for the STM32WL internal SX126x radio.
+ *
+ * This file replaces sx126x_ral_bsp.c when CONFIG_SEMTECH_SX126X_STM32WL is
+ * set. The main difference from the generic version is the TX config function,
+ * which uses the LP PA parameters required by the STM32WL LP path (same PA
+ * config as SX1261).
+ *
+ * Copyright (c) 2026 Semtech Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ * Created by Charles-Henri Hallard (charles@evolyenergy.com)
+ */
+
+#include <zephyr/kernel.h>
+
+#include <zephyr/usp/lora_lbm_transceiver.h>
+
+#include <sx126x.h>
+#include <ral_sx126x_bsp.h>
+#include "sx126x_stm32wl_hal_context.h"
+
+/* ---------------------------------------------------------------------------
+ * Helper: access the device config
+ * ---------------------------------------------------------------------------
+ */
+
+static inline const struct sx126x_stm32wl_hal_context_cfg_t* get_cfg( const void* context )
+{
+    const struct device* dev = context;
+    return dev->config;
+}
+
+static inline struct sx126x_stm32wl_hal_context_data_t* get_data( const void* context )
+{
+    const struct device* dev = context;
+    return dev->data;
+}
+
+/* ---------------------------------------------------------------------------
+ * RAL BSP API
+ * ---------------------------------------------------------------------------
+ */
+
+void ral_sx126x_bsp_get_reg_mode( const void* context, sx126x_reg_mod_t* reg_mode )
+{
+    *reg_mode = get_cfg( context )->reg_mode;
+}
+
+void ral_sx126x_bsp_get_rf_switch_cfg( const void* context, bool* dio2_is_set_as_rf_switch )
+{
+    *dio2_is_set_as_rf_switch = get_cfg( context )->dio2_tx_enable;
+}
+
+void ral_sx126x_bsp_get_tx_cfg( const void* context, const ral_sx126x_bsp_tx_cfg_input_params_t* input_params,
+                                ral_sx126x_bsp_tx_cfg_output_params_t* output_params )
+{
+    const struct sx126x_stm32wl_hal_context_cfg_t* config = get_cfg( context );
+
+    int8_t board_tx_pwr_offset_db = radio_utilities_get_tx_power_offset( context );
+    int16_t power = ( int16_t ) input_params->system_output_pwr_in_dbm + board_tx_pwr_offset_db;
+
+    output_params->pa_ramp_time = config->pa_ramp_time;
+    /* reserved value, same for all SX126x variants */
+    output_params->pa_cfg.pa_lut = 0x01;
+
+    if( config->pa_is_lp )
+    {
+        /* STM32WL LP PA — same register layout as SX1261 LP path.
+         * Maximum output power is board-configured (typically 14 dBm).
+         * PA settings: pa_duty_cycle=0x04, hp_max=0x00, device_sel=0x01. */
+        const int8_t max_power = config->pa_lp_max_power_dbm;
+
+        if( power > max_power )
+        {
+            power = max_power;
+        }
+        if( power < -17 )
+        {
+            power = -17;
+        }
+
+        output_params->pa_cfg.device_sel    = 0x01; /* LP PA */
+        output_params->pa_cfg.hp_max        = 0x00; /* not used on LP path */
+        output_params->pa_cfg.pa_duty_cycle = 0x04;
+        output_params->chip_output_pwr_in_dbm_configured = ( int8_t ) power;
+        output_params->chip_output_pwr_in_dbm_expected   = ( int8_t ) power;
+    }
+    else
+    {
+        /* STM32WL HP PA — register layout mirrors SX1262 HP path.
+         * Maximum output power is board-configured (rfo-hp-max-power). */
+        const int8_t max_power = config->pa_hp_max_power_dbm;
+
+        if( power > max_power )
+        {
+            power = max_power;
+        }
+        if( power < -9 )
+        {
+            power = -9;
+        }
+
+        /* Apply the STM32WL erratum workaround for RFO_HP antenna mismatch:
+         * set REG_TX_CLAMP_CFG bits [4:1] before any HP transmission.
+         * This is handled at the SX126x register level by the LBM — nothing
+         * extra is needed here in the BSP. */
+
+        output_params->pa_cfg.device_sel    = 0x00; /* HP PA */
+        output_params->pa_cfg.hp_max        = 0x07; /* max HP setting */
+        output_params->pa_cfg.pa_duty_cycle = 0x04;
+        output_params->chip_output_pwr_in_dbm_configured = ( int8_t ) power;
+        output_params->chip_output_pwr_in_dbm_expected   = ( int8_t ) power;
+    }
+}
+
+void ral_sx126x_bsp_get_xosc_cfg( const void* context, ral_xosc_cfg_t* xosc_cfg,
+                                  sx126x_tcxo_ctrl_voltages_t* supply_voltage,
+                                  uint32_t* startup_time_in_tick )
+{
+    const struct sx126x_hal_context_tcxo_cfg_t tcxo = get_cfg( context )->tcxo_cfg;
+
+    *xosc_cfg             = tcxo.xosc_cfg;
+    *supply_voltage       = tcxo.voltage;
+    *startup_time_in_tick = sx126x_convert_timeout_in_ms_to_rtc_step( tcxo.wakeup_time_ms );
+}
+
+void ral_sx126x_bsp_get_trim_cap( const void* context, uint8_t* trimming_cap_xta, uint8_t* trimming_cap_xtb )
+{
+    const struct sx126x_stm32wl_hal_context_cfg_t* config = get_cfg( context );
+
+    if( config->capa_xta != 0xFF )
+    {
+        *trimming_cap_xta = config->capa_xta;
+    }
+    if( config->capa_xtb != 0xFF )
+    {
+        *trimming_cap_xtb = config->capa_xtb;
+    }
+}
+
+void ral_sx126x_bsp_get_rx_boost_cfg( const void* context, bool* rx_boost_is_activated )
+{
+    *rx_boost_is_activated = get_cfg( context )->rx_boosted;
+}
+
+void ral_sx126x_bsp_get_ocp_value( const void* context, uint8_t* ocp_in_step_of_2_5_ma )
+{
+    /* Let the driver choose default values.
+     * LP PA default OCP (0x18 = 60 mA) is set by the LBM internally. */
+}
+
+void ral_sx126x_bsp_get_lora_cad_det_peak( const void* context, ral_lora_sf_t sf, ral_lora_bw_t bw,
+                                           ral_lora_cad_symbs_t nb_symbol, uint8_t* in_out_cad_det_peak )
+{
+    /* Fine-tune the CAD detection peak if needed */
+}
+
+/* ---------------------------------------------------------------------------
+ * TX power offset helpers
+ * ---------------------------------------------------------------------------
+ */
+
+void radio_utilities_set_tx_power_offset( const void* context, uint8_t tx_pwr_offset_db )
+{
+    get_data( context )->tx_power_offset_db_current = ( int8_t ) tx_pwr_offset_db;
+}
+
+uint8_t radio_utilities_get_tx_power_offset( const void* context )
+{
+    return ( uint8_t ) get_data( context )->tx_power_offset_db_current;
+}
+
+/* ---------------------------------------------------------------------------
+ * Power consumption tables (LP PA, LDO regulator mode — STM32WL typical)
+ * ---------------------------------------------------------------------------
+ */
+
+/* Values from SX1261 datasheet at 3.3 V / LDO */
+#define SX126X_LP_MIN_OUTPUT_POWER          -17
+#define SX126X_LP_MAX_OUTPUT_POWER           15
+#define SX126X_LP_CONVERT_TABLE_INDEX_OFFSET 17
+
+#define SX126X_GFSK_RX_CONSUMPTION_LDO         8000
+#define SX126X_GFSK_RX_BOOSTED_CONSUMPTION_LDO 9300
+#define SX126X_LORA_RX_CONSUMPTION_LDO         8880
+#define SX126X_LORA_RX_BOOSTED_CONSUMPTION_LDO 10100
+
+static const uint32_t ral_sx126x_convert_tx_dbm_to_ua_ldo_lp[] = {
+    9800,  /* -17 dBm */
+    10300, /* -16 dBm */
+    10500, /* -15 dBm */
+    10800, /* -14 dBm */
+    11100, /* -13 dBm */
+    11300, /* -12 dBm */
+    11600, /* -11 dBm */
+    11900, /* -10 dBm */
+    12400, /*  -9 dBm */
+    12900, /*  -8 dBm */
+    13400, /*  -7 dBm */
+    13900, /*  -6 dBm */
+    14500, /*  -5 dBm */
+    15300, /*  -4 dBm */
+    16000, /*  -3 dBm */
+    17000, /*  -2 dBm */
+    18000, /*  -1 dBm */
+    19000, /*   0 dBm */
+    20600, /*   1 dBm */
+    22000, /*   2 dBm */
+    23500, /*   3 dBm */
+    24900, /*   4 dBm */
+    26600, /*   5 dBm */
+    28400, /*   6 dBm */
+    30200, /*   7 dBm */
+    32000, /*   8 dBm */
+    34300, /*   9 dBm */
+    36600, /*  10 dBm */
+    39200, /*  11 dBm */
+    41700, /*  12 dBm */
+    44700, /*  13 dBm */
+    48200, /*  14 dBm */
+    52200, /*  15 dBm */
+};
+
+__weak ral_status_t ral_sx126x_bsp_get_instantaneous_tx_power_consumption(
+    const void* context, const ral_sx126x_bsp_tx_cfg_output_params_t* tx_cfg_output_params,
+    sx126x_reg_mod_t radio_reg_mode, uint32_t* pwr_consumption_in_ua )
+{
+    uint8_t index = 0;
+    int8_t  pwr   = tx_cfg_output_params->chip_output_pwr_in_dbm_expected;
+
+    if( pwr > SX126X_LP_MAX_OUTPUT_POWER )
+    {
+        index = SX126X_LP_MAX_OUTPUT_POWER + SX126X_LP_CONVERT_TABLE_INDEX_OFFSET;
+    }
+    else if( pwr < SX126X_LP_MIN_OUTPUT_POWER )
+    {
+        index = 0;
+    }
+    else
+    {
+        index = ( uint8_t )( pwr + SX126X_LP_CONVERT_TABLE_INDEX_OFFSET );
+    }
+
+    *pwr_consumption_in_ua = ral_sx126x_convert_tx_dbm_to_ua_ldo_lp[index];
+    return RAL_STATUS_OK;
+}
+
+__weak ral_status_t ral_sx126x_bsp_get_instantaneous_gfsk_rx_power_consumption(
+    const void* context, sx126x_reg_mod_t radio_reg_mode, bool rx_boosted,
+    uint32_t* pwr_consumption_in_ua )
+{
+    *pwr_consumption_in_ua = rx_boosted
+        ? SX126X_GFSK_RX_BOOSTED_CONSUMPTION_LDO
+        : SX126X_GFSK_RX_CONSUMPTION_LDO;
+    return RAL_STATUS_OK;
+}
+
+__weak ral_status_t ral_sx126x_bsp_get_instantaneous_lora_rx_power_consumption(
+    const void* context, sx126x_reg_mod_t radio_reg_mode, bool rx_boosted,
+    uint32_t* pwr_consumption_in_ua )
+{
+    *pwr_consumption_in_ua = rx_boosted
+        ? SX126X_LORA_RX_BOOSTED_CONSUMPTION_LDO
+        : SX126X_LORA_RX_CONSUMPTION_LDO;
+    return RAL_STATUS_OK;
+}

--- a/drivers/usp/sx126x/sx126x_stm32wl_hal_context.h
+++ b/drivers/usp/sx126x/sx126x_stm32wl_hal_context.h
@@ -1,0 +1,105 @@
+/**
+ * @file      sx126x_stm32wl_hal_context.h
+ *
+ * @brief     Device driver context for the STM32WL internal SX126x radio.
+ *
+ * Unlike the external SPI radio (sx126x_hal_context.h), the STM32WL variant
+ * has no external GPIO pins for reset, busy, or DIOs. Those signals are
+ * accessed through CPU-internal registers (RCC, PWR, EXTI).
+ *
+ * Copyright (c) 2026 Semtech Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ * Created by Charles-Henri Hallard (charles@evolyenergy.com)
+ */
+
+#ifndef SX126X_STM32WL_HAL_CONTEXT_H
+#define SX126X_STM32WL_HAL_CONTEXT_H
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/spi.h>
+
+#include <ral_sx126x_bsp.h>
+#include <sx126x.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Reuse the TCXO config struct from the standard context */
+struct sx126x_hal_context_tcxo_cfg_t
+{
+    ral_xosc_cfg_t              xosc_cfg;
+    sx126x_tcxo_ctrl_voltages_t voltage;
+    uint32_t                    wakeup_time_ms;
+};
+
+/**
+ * @brief Compile-time configuration for the STM32WL internal radio.
+ *
+ * Populated by the DTS macro SX126X_STM32WL_CONFIG(node_id).
+ */
+struct sx126x_stm32wl_hal_context_cfg_t
+{
+    struct spi_dt_spec spi; /* subghzspi bus spec */
+
+    /* External RF switch GPIOs (optional — absent when dio2-tx-enable is used).
+     * RAK3172_SIP / RAK3172LP_SIP : PA1 = RF_TX (ACTIVE_HIGH), PA0 = RF_RX (ACTIVE_HIGH)
+     * NUCLEO-WL55JC               : PC4 = FE_CTRL1 TX (ACTIVE_LOW), PC5 = FE_CTRL2 RX (ACTIVE_LOW)
+     * Note: plain RAK3172 uses an external SX1262 over SPI — it does NOT use this driver. */
+    struct gpio_dt_spec tx_rf_switch;
+    struct gpio_dt_spec rx_rf_switch;
+
+    bool                                 dio2_tx_enable;
+    struct sx126x_hal_context_tcxo_cfg_t tcxo_cfg;
+    uint8_t                              capa_xta; /* 0xFF = not set */
+    uint8_t                              capa_xtb; /* 0xFF = not set */
+
+    sx126x_reg_mod_t   reg_mode;
+    int8_t             tx_power_offset_db;
+    bool               rx_boosted;
+    sx126x_ramp_time_t pa_ramp_time;
+
+    /* PA output type and per-variant max power */
+    bool               pa_is_lp;
+    int8_t             pa_lp_max_power_dbm; /* max TX power for LP PA in dBm */
+    int8_t             pa_hp_max_power_dbm; /* max TX power for HP PA in dBm */
+};
+
+/* Current sleep state of the internal radio */
+typedef enum
+{
+    RADIO_SLEEP,
+    RADIO_AWAKE
+} radio_sleep_status_t;
+
+/* Callback type used by the board layer to notify the USP stack of a DIO event */
+typedef void ( *event_cb_t )( const struct device* dev );
+
+/**
+ * @brief Runtime data for the STM32WL internal radio device.
+ */
+struct sx126x_stm32wl_hal_context_data_t
+{
+#ifdef CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER
+    const struct device* sx126x_dev;
+    event_cb_t           event_interrupt_cb;
+#ifdef CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_GLOBAL_THREAD
+    struct k_work work;
+#endif
+#ifdef CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_OWN_THREAD
+    K_THREAD_STACK_MEMBER( thread_stack, CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_THREAD_STACK_SIZE );
+    struct k_thread thread;
+    struct k_sem    gpio_sem;
+#endif
+#endif /* CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER */
+
+    radio_sleep_status_t radio_status;
+    int8_t               tx_power_offset_db_current;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SX126X_STM32WL_HAL_CONTEXT_H */

--- a/dts/bindings/usp/semtech,sx126x-stm32wl.yaml
+++ b/dts/bindings/usp/semtech,sx126x-stm32wl.yaml
@@ -1,0 +1,116 @@
+# Copyright (c) 2026 Semtech Corporation
+# SPDX-License-Identifier: Apache-2.0
+# Created by Charles-Henri Hallard (charles@evolyenergy.com)
+
+# Binding for the STM32WL internal SX126x-compatible radio.
+# This binding extends the st,stm32wl-subghz-radio node with USP-specific
+# properties. Reset and busy signals are internal to the STM32WL CPU and
+# are accessed via LL register functions, not GPIO pins.
+#
+# Property names are intentionally aligned with semtech,sx126x-base.yaml
+# (Zephyr native LoRa driver) for consistency.
+
+description: |
+  Semtech SX126x radio - STM32WL internal variant (no external GPIO reset/busy).
+  Supported boards using this binding:
+    - RAK3172_SIP  (STM32WLE5CC, HP PA +22 dBm, RF switch PA1/PA0 ACTIVE_HIGH, LDO)
+    - RAK3172LP_SIP (STM32WLE5JC, LP PA +14 dBm, RF switch PA1/PA0 ACTIVE_HIGH, LDO)
+    - NUCLEO-WL55JC (STM32WL55JC, HP PA +22 dBm, RF switch PC4/PC5 ACTIVE_LOW, DC-DC)
+  Note: plain RAK3172 uses an external SX1262 over SPI and does NOT use this binding.
+
+compatible: "semtech,sx126x-stm32wl"
+
+include: spi-device.yaml
+
+properties:
+  dio2-tx-enable:
+    type: boolean
+    description: |
+      Use the radio's internal DIO2 to drive an RF switch selecting between
+      TX and RX paths. When enabled, DIO2 goes high when the chip is
+      transmitting. On STM32WL, this maps to the internal TX/RX switch.
+      Leave absent when using tx-enable-gpios / rx-enable-gpios instead.
+
+  dio3-tcxo-voltage:
+    type: int
+    description: |
+      Supply voltage driven on DIO3 to power an external TCXO.
+      See constants SX126X_DIO3_TCXO_* in dt-bindings/lora/sx126x.h
+      (same values as SX126X_TCXO_SUPPLY_* in dt-bindings/usp/sx126x.h).
+      Omit this property if no TCXO is present (crystal oscillator used).
+
+  tcxo-power-startup-delay-ms:
+    type: int
+    description: |
+      Startup (stabilization) delay of the TCXO in milliseconds after DIO3
+      is asserted. Omit or set to 0 if no TCXO is used.
+
+  regulator-ldo:
+    type: boolean
+    description: |
+      Use the LDO power regulator inside the radio (default mode).
+      When absent, the DC-DC converter is used instead.
+      Most boards without an external inductor must set this.
+
+  power-amplifier-output:
+    type: string
+    required: true
+    enum:
+      - "rfo-lp"
+      - "rfo-hp"
+    description: |
+      PA output path used on this board.
+      rfo-lp: low-power PA output (up to +14 dBm on STM32WL LP).
+      rfo-hp: high-power PA output (up to +22 dBm on STM32WL HP).
+
+  rfo-lp-max-power:
+    type: int
+    enum: [10, 14, 15]
+    description: |
+      Maximum TX output power in dBm when using the LP PA.
+      Allowed values: 10, 14, or 15. Defaults to 14 dBm.
+    default: 14
+
+  rfo-hp-max-power:
+    type: int
+    enum: [14, 17, 20, 22]
+    description: |
+      Maximum TX output power in dBm when using the HP PA.
+      Allowed values: 14, 17, 20, or 22. Defaults to 22 dBm.
+    default: 22
+
+  tx-enable-gpios:
+    type: phandle-array
+    description: |
+      GPIO driven HIGH to enable the TX RF path on an external RF switch.
+      When present the driver asserts it before sending SetTx to the radio
+      and deasserts it on standby/sleep. Leave absent when using
+      dio2-tx-enable instead.
+
+  rx-enable-gpios:
+    type: phandle-array
+    description: |
+      GPIO driven HIGH to enable the RX RF path on an external RF switch.
+      When present the driver asserts it before sending SetRx to the radio
+      and deasserts it on standby/sleep. Leave absent when using
+      dio2-tx-enable instead.
+
+  rx-boosted:
+    type: boolean
+    description: |
+      Enable RX Boosted mode for ~2 dB better sensitivity at the cost of
+      ~2 mA extra current in RX mode.
+
+  tx-power-offset:
+    type: int
+    description: |
+      Board-level TX power offset in dB applied on top of the requested
+      output power. Defaults to 0.
+
+  pa-ramp-time:
+    type: int
+    required: false
+    enum: [0, 1, 2, 3, 4, 5, 6, 7]
+    description: |
+      PA ramp-up time index (0 = 10 us ... 7 = 3400 us).
+      Default (0x02) corresponds to 40 us.

--- a/modules/usp/CMakeLists.txt
+++ b/modules/usp/CMakeLists.txt
@@ -25,8 +25,14 @@ if(CONFIG_ZEPHYR_USP_MODULE)
       include(${CMAKE_CURRENT_LIST_DIR}/../usp_drivers/lr20xx.cmake)
     endif()
 
-    if(CONFIG_SEMTECH_SX126X)
+    if(CONFIG_SEMTECH_SX126X OR CONFIG_SEMTECH_SX126X_STM32WL)
       include(${CMAKE_CURRENT_LIST_DIR}/../usp_drivers/sx126x.cmake)
+    endif()
+
+    # STM32WL LP PA behaves like SX1261; set the compile definition so the
+    # LBM core library selects the correct LP PA register settings.
+    if(CONFIG_SEMTECH_SX126X_STM32WL)
+      zephyr_library_compile_definitions(SX1261)
     endif()
 
     if(CONFIG_LORA_BASICS_MODEM_DRIVERS_RAL_RALF)

--- a/samples/usp/lbm/lctt_certif/boards/nucleo_wl55jc.conf
+++ b/samples/usp/lbm/lctt_certif/boards/nucleo_wl55jc.conf
@@ -1,0 +1,15 @@
+# Copyright (c) 2026 Semtech Corporation
+# SPDX-License-Identifier: Apache-2.0
+# Created by Charles-Henri Hallard (charles@evolyenergy.com)
+
+# Disable the native Zephyr LoRa driver — USP uses its own STM32WL HAL
+CONFIG_LORA=n
+CONFIG_SEMTECH_SX126X=n
+
+# USP STM32WL internal radio driver
+CONFIG_SEMTECH_SX126X_STM32WL=y
+
+CONFIG_GPIO=y
+CONFIG_SERIAL=y
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y

--- a/samples/usp/lbm/lctt_certif/boards/nucleo_wl55jc.overlay
+++ b/samples/usp/lbm/lctt_certif/boards/nucleo_wl55jc.overlay
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Semtech Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ * Created by Charles-Henri Hallard (charles@evolyenergy.com)
+ *
+ * Board overlay for ST NUCLEO-WL55JC (STM32WL55JC, HP PA).
+ *
+ * The base board DTS already contains all radio properties matching
+ * the USP binding: RF switch (PC4/PC5 ACTIVE_LOW), TCXO (DIO3 1.7V 5ms),
+ * PA config (rfo-hp +22dBm). No regulator-ldo: DC-DC converter used.
+ */
+
+&subghzspi {
+    status = "okay";
+
+    lora_usp: radio@0 {
+        compatible = "semtech,sx126x-stm32wl";
+        status = "okay";
+        spi-max-frequency = <8000000>;
+    };
+};
+
+/ {
+    aliases {
+        lora-transceiver   = &lora_usp;
+        lctt-certif-button = &user_button_1; /* SW1 = PA0 */
+    };
+
+    chosen {
+        zephyr,lorawan-transceiver = &lora_usp;
+    };
+};
+
+/* LoRaWAN credentials (placeholder — replace with real values before flashing) */
+#include "user_keys.overlay"

--- a/samples/usp/lbm/periodical_uplink/boards/nucleo_wl55jc.conf
+++ b/samples/usp/lbm/periodical_uplink/boards/nucleo_wl55jc.conf
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 Semtech Corporation
+# SPDX-License-Identifier: Apache-2.0
+# Created by Charles-Henri Hallard (charles@evolyenergy.com)
+#
+# Board-specific Kconfig for ST NUCLEO-WL55JC (STM32WL55JC).
+
+# Disable the native Zephyr LoRa driver — USP uses its own STM32WL HAL
+CONFIG_LORA=n
+CONFIG_SEMTECH_SX126X=n
+
+# USP STM32WL internal radio driver
+CONFIG_SEMTECH_SX126X_STM32WL=y
+
+CONFIG_GPIO=y
+CONFIG_SERIAL=y
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y

--- a/samples/usp/lbm/periodical_uplink/boards/nucleo_wl55jc.overlay
+++ b/samples/usp/lbm/periodical_uplink/boards/nucleo_wl55jc.overlay
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Semtech Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ * Created by Charles-Henri Hallard (charles@evolyenergy.com)
+ *
+ * Board overlay for ST NUCLEO-WL55JC (STM32WL55JC, HP PA).
+ *
+ * The base board DTS (nucleo_wl55jc.dts) already contains all hardware
+ * properties needed by the USP binding (property names match native Zephyr):
+ *   - tx-enable-gpios (PC4 / FE_CTRL1, ACTIVE_LOW)
+ *   - rx-enable-gpios (PC5 / FE_CTRL2, ACTIVE_LOW)
+ *   - dio3-tcxo-voltage = <SX126X_DIO3_TCXO_1V7>
+ *   - tcxo-power-startup-delay-ms = <5>
+ *   - power-amplifier-output = "rfo-hp"
+ *   - rfo-lp-max-power = <15>
+ *   - rfo-hp-max-power = <22>
+ *
+ * We only need to:
+ *   1. Replace the compatible with "semtech,sx126x-stm32wl".
+ *   2. Add spi-max-frequency (required by spi-device.yaml).
+ *   3. Wire up aliases/chosen for the USP framework.
+ *
+ * No regulator-ldo: NUCLEO-WL55JC has an external DC-DC inductor (L2)
+ * so the DC-DC converter is used (better efficiency).
+ *
+ * Console stays on lpuart1 (PA2/PA3) — the board default.
+ */
+
+&subghzspi {
+    status = "okay";
+
+    lora_usp: radio@0 {
+        /* Use the STM32WL internal-radio USP driver. */
+        compatible = "semtech,sx126x-stm32wl";
+        status = "okay";
+
+        /* SPI speed (required by spi-device.yaml) */
+        spi-max-frequency = <8000000>;
+
+        /* All radio properties (RF switch, TCXO, PA) are inherited
+         * from nucleo_wl55jc.dts — no overrides needed. */
+
+        /* No regulator-ldo: DC-DC converter used (external inductor). */
+    };
+};
+
+/* Alias required by USP sample applications */
+/ {
+    aliases {
+        lora-transceiver0 = &lora_usp;
+    };
+
+    chosen {
+        zephyr,lorawan-transceiver = &lora_usp;
+    };
+};
+
+/* LoRaWAN credentials (placeholder — replace with real values before flashing) */
+#include "user_keys.overlay"

--- a/samples/usp/lbm/porting_tests/boards/nucleo_wl55jc.conf
+++ b/samples/usp/lbm/porting_tests/boards/nucleo_wl55jc.conf
@@ -1,0 +1,15 @@
+# Copyright (c) 2026 Semtech Corporation
+# SPDX-License-Identifier: Apache-2.0
+# Created by Charles-Henri Hallard (charles@evolyenergy.com)
+
+# Disable the native Zephyr LoRa driver — USP uses its own STM32WL HAL
+CONFIG_LORA=n
+CONFIG_SEMTECH_SX126X=n
+
+# USP STM32WL internal radio driver
+CONFIG_SEMTECH_SX126X_STM32WL=y
+
+CONFIG_GPIO=y
+CONFIG_SERIAL=y
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y

--- a/samples/usp/lbm/porting_tests/boards/nucleo_wl55jc.overlay
+++ b/samples/usp/lbm/porting_tests/boards/nucleo_wl55jc.overlay
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Semtech Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ * Created by Charles-Henri Hallard (charles@evolyenergy.com)
+ *
+ * Board overlay for ST NUCLEO-WL55JC (STM32WL55JC, HP PA).
+ *
+ * The base board DTS already contains all radio properties matching
+ * the USP binding: RF switch (PC4/PC5 ACTIVE_LOW), TCXO (DIO3 1.7V 5ms),
+ * PA config (rfo-hp +22dBm). No regulator-ldo: DC-DC converter used.
+ */
+
+&subghzspi {
+    status = "okay";
+
+    lora_usp: radio@0 {
+        compatible = "semtech,sx126x-stm32wl";
+        status = "okay";
+        spi-max-frequency = <8000000>;
+    };
+};
+
+/ {
+    aliases {
+        lora-transceiver = &lora_usp;
+    };
+
+    chosen {
+        zephyr,lorawan-transceiver = &lora_usp;
+    };
+};

--- a/samples/usp/lbm/porting_tests/src/main.c
+++ b/samples/usp/lbm/porting_tests/src/main.c
@@ -115,19 +115,29 @@ typedef enum return_code_test_e
  */
 
 #if defined( SX128X )
-static ralf_t modem_radio = RALF_SX128X_INSTANTIATE( NULL );
+static ralf_t modem_radio  = RALF_SX128X_INSTANTIATE( NULL );
+#define RADIO_HAL_NAME "SX128x (SPI)"
 #elif defined( SX126X )
-static ralf_t modem_radio = RALF_SX126X_INSTANTIATE( NULL );
+static ralf_t modem_radio  = RALF_SX126X_INSTANTIATE( NULL );
+#if IS_ENABLED( CONFIG_SEMTECH_SX126X_STM32WL )
+#define RADIO_HAL_NAME "SX126x STM32WL (internal subghzspi)"
+#else
+#define RADIO_HAL_NAME "SX126x (SPI)"
+#endif
 #elif defined( LR11XX )
-static ralf_t modem_radio = RALF_LR11XX_INSTANTIATE( NULL );
+static ralf_t modem_radio  = RALF_LR11XX_INSTANTIATE( NULL );
+#define RADIO_HAL_NAME "LR11xx (SPI)"
 #elif defined( LR20XX )
-static ralf_t modem_radio = RALF_LR20XX_INSTANTIATE( NULL );
+static ralf_t modem_radio  = RALF_LR20XX_INSTANTIATE( NULL );
+#define RADIO_HAL_NAME "LR20xx (SPI)"
 #elif defined( SX127X )
 #include "sx127x.h"
 static sx127x_t sx127x;
 static ralf_t   modem_radio = RALF_SX127X_INSTANTIATE( &sx127x );
+#define RADIO_HAL_NAME "SX127x (SPI)"
 #else
 #error "Please select radio board.."
+#define RADIO_HAL_NAME "unknown"
 #endif
 
 /* lr11xx radio context and its use in the ralf layer */
@@ -217,7 +227,8 @@ int main( void )
 
     LOG_INF( "" );
     LOG_INF( "" );
-    LOG_INF( "PORTING_TESTS example is starting" );
+    LOG_INF( "PORTING_TESTS example on " CONFIG_BOARD " is starting" );
+    LOG_INF( "Radio/shield : " RADIO_HAL_NAME );
     LOG_INF( "" );
     LOG_INF( "" );
 


### PR DESCRIPTION
## Summary

Adds full support for the STM32WL internal SX126x-compatible radio (STM32WLE5 / STM32WL55) to the USP framework, along with board files for NUCLEO-WL55JC across all three LBM samples.

### DTS binding (`dts/bindings/usp/semtech,sx126x-stm32wl.yaml`)
New binding extending `spi-device.yaml` with USP-specific properties aligned with native Zephyr `semtech,sx126x-base.yaml` naming:
- `dio3-tcxo-voltage` / `tcxo-power-startup-delay-ms`
- `regulator-ldo` (boolean, absent = DC-DC)
- `power-amplifier-output`: `rfo-lp` or `rfo-hp` with per-variant max power
- `tx-enable-gpios` / `rx-enable-gpios` (external RF switch, polarity from DTS flags)
- No external reset/busy GPIO — accessed via internal RCC/PWR registers

Supported boards: RAK3172_SIP (HP, LDO), RAK3172LP_SIP (LP, LDO), NUCLEO-WL55JC (HP, DC-DC).

### Driver (`drivers/usp/sx126x/`)
New STM32WL-specific HAL replacing `sx126x_hal.c` / `sx126x_board.c` when `CONFIG_SEMTECH_SX126X_STM32WL=y`:
- **SPI**: internal `subghzspi` peripheral instead of external SPI + NSS GPIO
- **Reset**: `LL_RCC_RF_EnableReset()` / `LL_RCC_RF_DisableReset()` instead of GPIO
- **Busy**: polls `PWR_SR2.RFBUSYS` *after* SPI transaction (polling before causes deadlock)
- **IRQ**: NVIC IRQ 50 (`SUBGHZ_Radio_IRQn`) is level-triggered — disabled in ISR, re-enabled after each `sx126x_hal_write()` to prevent IRQ storm
- **RF switch**: MCU GPIOs driven before SetTx/SetRx with active level from DTS flags
- **PA**: supports both HP (`rfo-hp`) and LP (`rfo-lp`) via `pa_is_lp` flag; USP library built with `SX1261` define for STM32WL PA register layout

Build system: `Kconfig.sx12xx`, `CMakeLists.txt` and `modules/usp/CMakeLists.txt` updated to conditionally compile STM32WL sources and pass `SX1261` to the USP library.

Documentation: `STM32WL_vs_SX1262.md` covers all architectural differences with a board comparison table (RAK3172, RAK3172_SIP, RAK3172LP_SIP, NUCLEO-WL55JC).

### Board support — NUCLEO-WL55JC (`samples/usp/lbm/*/boards/`)
Overlay and Kconfig for all three LBM samples:
- `periodical_uplink`: alias `lora-transceiver0`, includes `user_keys.overlay`
- `porting_tests`: alias `lora-transceiver`, startup banner prints board name and radio HAL
- `lctt_certif`: alias `lora-transceiver`, `lctt-certif-button = &user_button_1` (SW1/PA0), includes `user_keys.overlay`

🤖 Generated with [Claude Code](https://claude.com/claude-code)